### PR TITLE
Fix inconsistent theme on first launch and restart

### DIFF
--- a/GenshinLyreMidiPlayer.WPF/GenshinLyreMidiPlayer.WPF.csproj
+++ b/GenshinLyreMidiPlayer.WPF/GenshinLyreMidiPlayer.WPF.csproj
@@ -6,7 +6,7 @@
         <UseWPF>true</UseWPF>
         <StartupObject>GenshinLyreMidiPlayer.WPF.App</StartupObject>
         <ApplicationManifest>app.manifest</ApplicationManifest>
-        <Version>4.0.2</Version>
+        <Version>4.0.3</Version>
         <ApplicationIcon>item_windsong_lyre.ico</ApplicationIcon>
         <Nullable>enable</Nullable>
         <RepositoryUrl>https://github.com/sabihoshi/GenshinLyreMidiPlayer</RepositoryUrl>

--- a/GenshinLyreMidiPlayer.WPF/ViewModels/MainWindowViewModel.cs
+++ b/GenshinLyreMidiPlayer.WPF/ViewModels/MainWindowViewModel.cs
@@ -87,7 +87,13 @@ public class MainWindowViewModel : Conductor<IScreen>
     protected override async void OnViewLoaded()
     {
         Navigation = ((MainWindowView) View).RootNavigation;
-        _theme.SetTheme(_theme.GetSystemTheme());
+
+        _theme.SetTheme(ThemeManager.Current.ApplicationTheme switch
+        {
+            ApplicationTheme.Light => ThemeType.Light,
+            ApplicationTheme.Dark  => ThemeType.Dark,
+            _                      => SettingsView.GetSystemTheme()
+        });
 
         if (!await SettingsView.TryGetLocationAsync()) _ = SettingsView.LocationMissing();
         if (SettingsView.AutoCheckUpdates)

--- a/GenshinLyreMidiPlayer.WPF/ViewModels/SettingsPageViewModel.cs
+++ b/GenshinLyreMidiPlayer.WPF/ViewModels/SettingsPageViewModel.cs
@@ -316,6 +316,13 @@ public class SettingsPageViewModel : Screen
         PlayTimerToken = null;
     }
 
+    public ThemeType GetSystemTheme()
+    {
+        var SystemThemeColor = new Windows.UI.ViewManagement.UISettings().GetColorValue(Windows.UI.ViewManagement.UIColorType.Background).ToString();
+        var SystemTheme = SystemThemeColor == "#FFFFFFFF" ? ThemeType.Light : ThemeType.Dark;
+        return SystemTheme;
+    }
+
     [UsedImplicitly]
     public void OnThemeChanged()
     {
@@ -323,7 +330,7 @@ public class SettingsPageViewModel : Screen
         {
             ApplicationTheme.Light => ThemeType.Light,
             ApplicationTheme.Dark  => ThemeType.Dark,
-            _                      => _theme.GetSystemTheme()
+            _                      => GetSystemTheme()
         });
 
         Settings.Modify(s => s.AppTheme = (int?) ThemeManager.Current.ApplicationTheme ?? -1);
@@ -348,8 +355,9 @@ public class SettingsPageViewModel : Screen
                 Title   = "Incorrect Location",
                 Content = "launcher.exe is not the game, please find GenshinImpact.exe",
 
-                CloseButtonText = "Ok"
+                CloseButtonText = "Ok",
             };
+            
 
             await dialog.ShowAsync();
             return false;

--- a/GenshinLyreMidiPlayer.WPF/Views/LyrePlayerView.xaml
+++ b/GenshinLyreMidiPlayer.WPF/Views/LyrePlayerView.xaml
@@ -25,7 +25,7 @@
 
 		<modern:SimpleStackPanel Orientation="Horizontal" Grid.Row="0">
 			<Button Command="{s:Action OpenFile}" Background="Transparent">
-                <modern:FontIcon Glyph="&#xE8E5;"  />
+                <modern:FontIcon Glyph="&#xE8E5;" />
 			</Button>
 			<TextBlock VerticalAlignment="Center" Text="{Binding Playlist.OpenedFile.Title, Mode=OneWay, FallbackValue=Open...}" />
 		</modern:SimpleStackPanel>
@@ -41,19 +41,19 @@
 
 			<Button Command="{s:Action Previous}"
 			        IsHitTestVisible="{Binding CanHitPrevious}">
-                <modern:FontIcon Glyph="&#xE892;"  />
+                <modern:FontIcon Glyph="&#xE892;" />
 			</Button>
 			<Button Command="{s:Action PlayPause}"
 			        IsHitTestVisible="{Binding CanHitPlayPause}">
-                <modern:FontIcon Glyph="{Binding PlayPauseIcon}"  />
+                <modern:FontIcon Glyph="{Binding PlayPauseIcon}" />
 			</Button>
 			<Button Command="{s:Action Next}"
 			        IsHitTestVisible="{Binding CanHitNext}">
-                <modern:FontIcon Glyph="&#xE893;"  />
+                <modern:FontIcon Glyph="&#xE893;" />
 			</Button>
 
 			<Button s:View.ActionTarget="{Binding Playlist}" Command="{s:Action ToggleLoop}">
-                <modern:FontIcon Glyph="{Binding Playlist.LoopStateString}"  />
+                <modern:FontIcon Glyph="{Binding Playlist.LoopStateString}" />
 			</Button>
 		</modern:SimpleStackPanel>
 
@@ -120,7 +120,7 @@
 					SelectedItem="{Binding SelectedMidiInput}"
 					DisplayMemberPath="DeviceName" />
 				<Button Command="{s:Action RefreshDevices}">
-                    <modern:FontIcon Glyph="&#xE72C;"  />
+                    <modern:FontIcon Glyph="&#xE72C;" />
 				</Button>
 			</modern:SimpleStackPanel>
 		</GroupBox>


### PR DESCRIPTION
Tested on Windows 10 version 21H1, should to be tested on Windows 11 to make sure the option **Use system setting** under **Theme Mode** works correctly

- The method to get the current system theme has been changed, the previously used `_theme.GetSystemTheme()` returned the **Windows mode** theme instead of the **app mode** theme and caused issues when these two values were different (such as the `ContentDialog` having invisible buttons or text being the wrong color)
![Screenshot](https://user-images.githubusercontent.com/31524206/191390283-68824219-230a-4e99-b974-76aa7cb081e4.png)

- The **Theme** setting will now persist between application restarts

- Solves https://github.com/sabihoshi/GenshinLyreMidiPlayer/issues/29
